### PR TITLE
Autodiscover lamp in HA device registry

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -3,191 +3,191 @@
     {
       "id": "SparklesEffect",
       "name": "Sparkles",
-      "speed": 32,
-      "scale": 16,
+      "speed": 121,
+      "scale": 12,
       "brightness": 255
     },
     {
       "id": "FireEffect",
       "name": "Fire",
-      "speed": 0,
-      "scale": 0,
-      "brightness": 255
+      "speed": 37,
+      "scale": 1,
+      "brightness": 80
     },
     {
       "id": "VerticalRainbowEffect",
       "name": "Vertical rainbow",
-      "speed": 16,
-      "scale": 16,
-      "brightness": 255
+      "speed": 100,
+      "scale": 18,
+      "brightness": 80
     },
     {
       "id": "HorizontalRainbowEffect",
       "name": "Horizontal rainbow",
-      "speed": 16,
-      "scale": 16,
-      "brightness": 255
+      "speed": 100,
+      "scale": 18,
+      "brightness": 80
     },
     {
       "id": "ColorsEffect",
       "name": "Color change",
-      "speed": 64,
+      "speed": 112,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "MadnessNoiseEffect",
       "name": "Madness 3D",
       "speed": 50,
       "scale": 100,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "CloudNoiseEffect",
       "name": "Clouds 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "LavaNoiseEffect",
       "name": "Lava 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "PlasmaNoiseEffect",
       "name": "Plasma 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "RainbowNoiseEffect",
       "name": "Rainbow 3D",
       "speed": 1,
       "scale": 52,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "RainbowStripeNoiseEffect",
       "name": "Rainbow stripe 3D",
       "speed": 1,
       "scale": 47,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "ZebraNoiseEffect",
       "name": "Zebra 3D",
       "speed": 1,
-      "scale": 32,
-      "brightness": 255
+      "scale": 26,
+      "brightness": 80
     },
     {
       "id": "ForestNoiseEffect",
       "name": "Forest 3D",
       "speed": 1,
       "scale": 64,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "OceanNoiseEffect",
       "name": "Ocean 3D",
       "speed": 1,
       "scale": 24,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "ColorEffect",
       "name": "Single color",
       "speed": 10,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "SnowEffect",
       "name": "Snow",
-      "speed": 64,
-      "scale": 50,
-      "brightness": 255
+      "speed": 255,
+      "scale": 33,
+      "brightness": 80
     },
     {
       "id": "MatrixEffect",
       "name": "Matrix",
-      "speed": 50,
-      "scale": 16,
-      "brightness": 255
+      "speed": 255,
+      "scale": 25,
+      "brightness": 80
     },
     {
       "id": "LightersEffect",
       "name": "Lighters",
-      "speed": 64,
-      "scale": 16,
-      "brightness": 255
+      "speed": 127,
+      "scale": 10,
+      "brightness": 80
     },
     {
       "id": "ClockEffect",
       "name": "Clock vertical",
-      "speed": 100,
+      "speed": 250,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "ClockHorizontal1Effect",
       "name": "Clock horizontal colored",
       "speed": 250,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "ClockHorizontal2Effect",
       "name": "Clock horizontal",
       "speed": 250,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "ClockHorizontal3Effect",
       "name": "Clock horizontal single",
       "speed": 250,
       "scale": 1,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "SoundEffect",
       "name": "Sound spectrometer",
       "speed": 1,
       "scale": 50,
-      "brightness": 255
+      "brightness": 236
     },
     {
       "id": "StarfallEffect",
       "name": "Starfall",
       "speed": 80,
       "scale": 100,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "DiagonalRainbowEffect",
       "name": "DiagonalRainbow",
-      "speed": 16,
-      "scale": 16,
-      "brightness": 255
+      "speed": 100,
+      "scale": 20,
+      "brightness": 80
     },
     {
       "id": "WaterfallEffect",
       "name": "Waterfall",
-      "speed": 50,
+      "speed": 100,
       "scale": 20,
-      "brightness": 255
+      "brightness": 80
     },
     {
       "id": "SoundStereoEffect",
       "name": "Sound stereo spectrometer",
       "speed": 1,
       "scale": 50,
-      "brightness": 255
+      "brightness": 236
     }
   ],
   "activeEffect": 1,
@@ -197,19 +197,19 @@
     "segments": 1,
     "type": 15,
     "maxBrightness": 255,
-    "currentLimit": 3000,
-    "rotation": 2
+    "currentLimit": 1500,
+    "rotation": 3
   },
   "connection": {
-    "mdns": "bedlamp",
-    "apName": "Bed Lamp",
-    "ntpServer": "192.168.1.3",
+    "mdns": "firelamp",
+    "apName": "Fire Lamp",
+    "ntpServer": "europe.pool.ntp.org",
     "ntpOffset": 10800
   },
   "mqtt": {
-    "host": "192.168.1.3",
+    "host": "",
     "port": 1883,
-    "username": "mqtt",
-    "password": "MQTTPassword"
+    "username": "",
+    "password": ""
   }
 }

--- a/data/settings.json
+++ b/data/settings.json
@@ -3,191 +3,191 @@
     {
       "id": "SparklesEffect",
       "name": "Sparkles",
-      "speed": 121,
-      "scale": 12,
+      "speed": 32,
+      "scale": 16,
       "brightness": 255
     },
     {
       "id": "FireEffect",
       "name": "Fire",
-      "speed": 37,
-      "scale": 1,
-      "brightness": 80
+      "speed": 0,
+      "scale": 0,
+      "brightness": 255
     },
     {
       "id": "VerticalRainbowEffect",
       "name": "Vertical rainbow",
-      "speed": 100,
-      "scale": 18,
-      "brightness": 80
+      "speed": 16,
+      "scale": 16,
+      "brightness": 255
     },
     {
       "id": "HorizontalRainbowEffect",
       "name": "Horizontal rainbow",
-      "speed": 100,
-      "scale": 18,
-      "brightness": 80
+      "speed": 16,
+      "scale": 16,
+      "brightness": 255
     },
     {
       "id": "ColorsEffect",
       "name": "Color change",
-      "speed": 112,
+      "speed": 64,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "MadnessNoiseEffect",
       "name": "Madness 3D",
       "speed": 50,
       "scale": 100,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "CloudNoiseEffect",
       "name": "Clouds 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "LavaNoiseEffect",
       "name": "Lava 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "PlasmaNoiseEffect",
       "name": "Plasma 3D",
       "speed": 1,
       "scale": 100,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "RainbowNoiseEffect",
       "name": "Rainbow 3D",
       "speed": 1,
       "scale": 52,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "RainbowStripeNoiseEffect",
       "name": "Rainbow stripe 3D",
       "speed": 1,
       "scale": 47,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "ZebraNoiseEffect",
       "name": "Zebra 3D",
       "speed": 1,
-      "scale": 26,
-      "brightness": 80
+      "scale": 32,
+      "brightness": 255
     },
     {
       "id": "ForestNoiseEffect",
       "name": "Forest 3D",
       "speed": 1,
       "scale": 64,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "OceanNoiseEffect",
       "name": "Ocean 3D",
       "speed": 1,
       "scale": 24,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "ColorEffect",
       "name": "Single color",
       "speed": 10,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "SnowEffect",
       "name": "Snow",
-      "speed": 255,
-      "scale": 33,
-      "brightness": 80
+      "speed": 64,
+      "scale": 50,
+      "brightness": 255
     },
     {
       "id": "MatrixEffect",
       "name": "Matrix",
-      "speed": 255,
-      "scale": 25,
-      "brightness": 80
+      "speed": 50,
+      "scale": 16,
+      "brightness": 255
     },
     {
       "id": "LightersEffect",
       "name": "Lighters",
-      "speed": 127,
-      "scale": 10,
-      "brightness": 80
+      "speed": 64,
+      "scale": 16,
+      "brightness": 255
     },
     {
       "id": "ClockEffect",
       "name": "Clock vertical",
-      "speed": 250,
+      "speed": 100,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "ClockHorizontal1Effect",
       "name": "Clock horizontal colored",
       "speed": 250,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "ClockHorizontal2Effect",
       "name": "Clock horizontal",
       "speed": 250,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "ClockHorizontal3Effect",
       "name": "Clock horizontal single",
       "speed": 250,
       "scale": 1,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "SoundEffect",
       "name": "Sound spectrometer",
       "speed": 1,
       "scale": 50,
-      "brightness": 236
+      "brightness": 255
     },
     {
       "id": "StarfallEffect",
       "name": "Starfall",
       "speed": 80,
       "scale": 100,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "DiagonalRainbowEffect",
       "name": "DiagonalRainbow",
-      "speed": 100,
-      "scale": 20,
-      "brightness": 80
+      "speed": 16,
+      "scale": 16,
+      "brightness": 255
     },
     {
       "id": "WaterfallEffect",
       "name": "Waterfall",
-      "speed": 100,
+      "speed": 50,
       "scale": 20,
-      "brightness": 80
+      "brightness": 255
     },
     {
       "id": "SoundStereoEffect",
       "name": "Sound stereo spectrometer",
       "speed": 1,
       "scale": 50,
-      "brightness": 236
+      "brightness": 255
     }
   ],
   "activeEffect": 1,
@@ -197,19 +197,19 @@
     "segments": 1,
     "type": 15,
     "maxBrightness": 255,
-    "currentLimit": 1500,
-    "rotation": 3
+    "currentLimit": 3000,
+    "rotation": 2
   },
   "connection": {
-    "mdns": "firelamp",
-    "apName": "Fire Lamp",
-    "ntpServer": "europe.pool.ntp.org",
+    "mdns": "bedlamp",
+    "apName": "Bed Lamp",
+    "ntpServer": "192.168.1.3",
     "ntpOffset": 10800
   },
   "mqtt": {
-    "host": "",
+    "host": "192.168.1.3",
     "port": 1883,
-    "username": "",
-    "password": ""
+    "username": "mqtt",
+    "password": "MQTTPassword"
   }
 }

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -79,7 +79,7 @@ void sendDiscovery()
     DynamicJsonDocument doc(1024*5);
     doc[F("~")] = commonTopic;
     doc[F("name")] = mySettings->connectionSettings.mdns;
-    doc[F("unique_id")] = String(ESP.getChipId(), HEX);
+    doc[F("uniq_id")] = String(ESP.getChipId(), HEX);
     doc[F("cmd_t")] = F("~/set");
     doc[F("stat_t")] = F("~/state");
     doc[F("avty_t")] = F("~/available");
@@ -88,9 +88,9 @@ void sendDiscovery()
     doc[F("schema")] = F("json");
     doc[F("brightness")] = true;
     doc[F("effect")] = true;
-    doc[F("device")][F("ids")] = doc[F("unique_id")];
-    doc[F("device")][F("name")] = mySettings->connectionSettings.mdns;
-    doc[F("device")][F("model")] = mySettings->connectionSettings.apName;
+    doc[F("dev")][F("ids")] = doc[F("uniq_id")];
+    doc[F("dev")][F("name")] = mySettings->connectionSettings.mdns;
+    doc[F("dev")][F("mdl")] = mySettings->connectionSettings.apName;
 
     JsonArray effects = doc.createNestedArray(F("effect_list"));
     mySettings->WriteEffectsMqtt(effects);

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -79,7 +79,7 @@ void sendDiscovery()
     DynamicJsonDocument doc(1024*5);
     doc[F("~")] = commonTopic;
     doc[F("name")] = mySettings->connectionSettings.mdns;
-    doc[F("uniq_id")] = String(ESP.getChipId(), HEX);
+    doc[F("uniq_id")] = mySettings->GetChipID();
     doc[F("cmd_t")] = F("~/set");
     doc[F("stat_t")] = F("~/state");
     doc[F("avty_t")] = F("~/available");

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -70,7 +70,7 @@ void sendState()
 void sendAvailability()
 {
     Serial.println(F("Sending availability"));
-    boolean success = client->publish_P(availabilityTopic.c_str(), PSTR("true"), false);
+    boolean success = client->publish_P(availabilityTopic.c_str(), PSTR("true"), true);
     Serial.printf_P(PSTR("Availability sent: %s\n"), success ? PSTR("success") : PSTR("fail"));
 }
 
@@ -79,7 +79,7 @@ void sendDiscovery()
     DynamicJsonDocument doc(1024*5);
     doc[F("~")] = commonTopic;
     doc[F("name")] = mySettings->connectionSettings.mdns;
-    doc[F("unique_id")] = mySettings->connectionSettings.mdns;
+    doc[F("unique_id")] = String(ESP.getChipId(), HEX);
     doc[F("cmd_t")] = F("~/set");
     doc[F("stat_t")] = F("~/state");
     doc[F("avty_t")] = F("~/available");
@@ -87,9 +87,10 @@ void sendDiscovery()
     doc[F("pl_not_avail")] = F("false");
     doc[F("schema")] = F("json");
     doc[F("brightness")] = true;
-//    doc[F("rgb")] = true;
     doc[F("effect")] = true;
-
+    doc[F("device")][F("ids")] = doc[F("unique_id")];
+    doc[F("device")][F("name")] = mySettings->connectionSettings.mdns;
+    doc[F("device")][F("model")] = mySettings->connectionSettings.apName;
 
     JsonArray effects = doc.createNestedArray(F("effect_list"));
     mySettings->WriteEffectsMqtt(effects);
@@ -118,8 +119,8 @@ void reconnect()
                             mySettings->mqttSettings.username.c_str(),
                             mySettings->mqttSettings.password.c_str(),
                             availabilityTopic.c_str(),
-                            0,
-                            false,
+                            1,
+                            true,
                             "false")) {
             Serial.println(F(" connected"));
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -186,6 +186,15 @@ void Settings::BuildJson(JsonObject &root)
     spectrometerObject[F("active")] = generalSettings.soundControl;
 }
 
+String Settings::GetChipID()
+{
+#if defined(ESP32)
+  return String((uint32_t)ESP.getEfuseMac(), HEX);
+#else
+  return String((uint32_t)ESP.getChipId(), HEX);
+#endif
+}
+
 void Settings::BuildJsonMqtt(JsonObject &root)
 {
     root[F("state")] = generalSettings.working ? F("ON") : F("OFF");

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -65,6 +65,8 @@ public:
     void ProcessConfig(const String &message);
     void ProcessCommandMqtt(const JsonObject &json);
 
+    String GetChipID();
+
     GeneralSettings generalSettings;
     MatrixSettings matrixSettings;
     ConenctionSettings connectionSettings;


### PR DESCRIPTION
Lets Homeassistant to add lamp into device registry.

Thats allow us to use simple automotions without yml editing.

Additionaly added retain message to availability on start if HA is down/rebooting at the moment of lamp booting.