### PR TITLE
Use default LDF mode

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,6 @@ lib_deps =
     Adafruit BusIO
 
 lib_ignore = Adafruit ILI9341
-lib_ldf_mode = off
 
 build_unflags       = -Werror=reorder
 build_flags         = -O2
@@ -54,9 +53,7 @@ lib_deps =
 
 lib_ignore =
     ${common.lib_ignore}
-
-lib_ldf_mode = ${common.lib_ldf_mode}
-
+    
 [esp32]
 lib_deps =
     WiFi
@@ -70,8 +67,6 @@ lib_deps =
 
 lib_ignore =
     ${common.lib_ignore}
-
-lib_ldf_mode = ${common.lib_ldf_mode}
 
 [env:sonoff-r1]
 framework                 = arduino
@@ -99,7 +94,6 @@ upload_speed              = ${common.upload_speed}
 upload_resetmethod        = nodemcu
 lib_deps                  = ${esp8266.lib_deps}
 lib_ignore                = ${esp8266.lib_ignore}
-lib_ldf_mode              = ${esp8266.lib_ldf_mode}
 
 [env:sonoff-r1-4m]
 framework                 = arduino
@@ -127,7 +121,6 @@ upload_speed              = ${common.upload_speed}
 upload_resetmethod        = nodemcu
 lib_deps                  = ${esp8266.lib_deps}
 lib_ignore                = ${esp8266.lib_ignore}
-lib_ldf_mode              = ${esp8266.lib_ldf_mode}
 
 [env:nodemcu]
 framework                 = arduino
@@ -146,7 +139,6 @@ upload_speed              = ${common.upload_speed}
 
 lib_deps                  = ${esp8266.lib_deps}
 lib_ignore                = ${esp8266.lib_ignore}
-lib_ldf_mode              = ${esp8266.lib_ldf_mode}
 
 [env:esp32dev]
 framework                 = arduino
@@ -161,4 +153,3 @@ upload_speed              = ${common.upload_speed}
 
 lib_deps                  = ${esp32.lib_deps}
 lib_ignore                = ${esp32.lib_ignore}
-lib_ldf_mode              = ${esp32.lib_ldf_mode}


### PR DESCRIPTION
https://community.platformio.org/t/pio-in-vscode-doesnt-find-any-libraries-including-built-in-ones/15777/4