### PR TITLE
[matrix] Fix for wrapX, wrapY

### DIFF
--- a/src/MyMatrix.cpp
+++ b/src/MyMatrix.cpp
@@ -242,12 +242,12 @@ void MyMatrix::dimAll(uint8_t value)
 
 uint8_t MyMatrix::wrapX(int8_t x)
 {
-    return mod8(x + 1, mySettings->matrixSettings.width);
+    return mod8(x + mySettings->matrixSettings.width, mySettings->matrixSettings.width);
 }
 
 uint8_t MyMatrix::wrapY(int8_t y)
 {
-    return mod8(y + 1, mySettings->matrixSettings.height);
+    return mod8(y + mySettings->matrixSettings.height, mySettings->matrixSettings.height);
 }
 
 void MyMatrix::fader(uint8_t step)


### PR DESCRIPTION
In commit a43a0d4a4a88696120954b06c0c041875921fda8 function changed from `(x + width) % width` to `(x + 1) % width` what breaks RainNew effect (no dropping rain, at least on my 15w10h matrix)

This PR fixes it.
Also confirmed working of Fire12 and Fire18 effects on my matrix with this fix.