### PR TITLE
MQTT filed switchTo added to be able to choose previous or next effect

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -299,6 +299,13 @@ void Settings::processCommandMqtt(const String &message)
             if (json.containsKey(F("effect"))) {
                 const String effect = json[F("effect")];
                 effectsManager->changeEffectByName(effect);
+            } else if (json.containsKey(F("switchTo"))) {
+                const String switchTo = json[F("switchTo")];
+                if (switchTo.equals(F("prev"))) {
+                    effectsManager->previous();
+                } else if (switchTo.equals(F("next"))) {
+                    effectsManager->next();
+                }
             }
             if (json.containsKey(F("color"))) {
                 effectsManager->changeEffectById(F("Color"));


### PR DESCRIPTION
'switchTo' mqtt field can have 'prev' or 'next' values. If 'state' send with value 'ON' and no effect specified - it will switch to previous or next effect accordingly.