### PR TITLE
LED Color order customization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -110,6 +110,11 @@ lib_deps                  = ${esp8266.lib_deps}
 lib_ignore                = ${esp8266.lib_ignore}
 lib_ldf_mode              = ${esp8266.lib_ldf_mode}
 
+[env:esp01s_rgb]
+extends                   = env:esp01s
+build_flags               = ${env:esp01s.build_flags}
+                            -DMY_MATRIX_LED_RGB_ORDER=RGB
+
 [env:sonoff-r1]
 platform                  = ${esp8266.platform}
 board                     = esp01_1m
@@ -182,3 +187,8 @@ upload_speed              = ${common.upload_speed}
 lib_deps                  = ${esp32.lib_deps}
 lib_ignore                = ${esp32.lib_ignore}
 lib_ldf_mode              = ${esp32.lib_ldf_mode}
+
+[env:esp32dev_rgb]
+extends                   = env:esp32dev
+build_flags               = ${env:esp32dev.build_flags}
+                            -DMY_MATRIX_LED_RGB_ORDER=RGB

--- a/src/MyMatrix.cpp
+++ b/src/MyMatrix.cpp
@@ -7,6 +7,15 @@
 #include "MyLedController32.h"
 #endif
 
+// MY_MATRIX_LED_RGB_ORDER need to be set to one of EOrder value
+// https://github.com/FastLED/FastLED/blob/master/src/pixeltypes.h#L939
+
+#ifdef MY_MATRIX_LED_RGB_ORDER
+#define _LED_RGB_ORDER MY_MATRIX_LED_RGB_ORDER
+#else
+#define _LED_RGB_ORDER GRB
+#endif
+
 namespace  {
 
 uint16_t numLeds = 0;
@@ -82,7 +91,7 @@ uint16_t XY(uint8_t x, uint8_t y) {
     return object->XY(x, y);
 }
 
-template <EOrder RGB_ORDER = RGB>
+template <EOrder RGB_ORDER>
 class WS2812CustomController : public ClocklessCustomController<C_NS(250), C_NS(625), C_NS(375), RGB_ORDER> {};
 
 FASTLED_NAMESPACE_END
@@ -107,7 +116,7 @@ void MyMatrix::Initialize()
 
     numLeds = sizeWidth * sizeHeight;
     leds = new CRGB[numLeds]();
-    FastLED.addLeds<WS2812CustomController, GRB>(leds, numLeds);
+    FastLED.addLeds<WS2812CustomController, _LED_RGB_ORDER>(leds, numLeds);
 
     uint8_t maxBrightness = mySettings->matrixSettings.maxBrightness;
     Serial.printf_P(PSTR("Set max brightness to: %u\n"), maxBrightness);


### PR DESCRIPTION
Hi!
Here is the patch to make LED Color order configurable at build-time.

First commit introduces a macro definition to override a default Color order in MyMatrix class.
The second one add project variants to build some firmware with different color order.

BR, Eugene Agafonov.

PS: Thanks for the awesome project!