### PR TITLE
Stabilize scrolling text updates

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,10 +20,10 @@ lib_deps =
     ESPAsyncE131-wled
     AsyncMqttClient-esphome@2.1.0
     ArduinoJson@6.21.5
-    https://github.com/me-no-dev/ESPAsyncWebServer.git#40a2fd71
-    https://github.com/coderus/ESPReactWifiManager.git#f8cb27d2
-    https://github.com/marcmerlin/FastLED_NeoMatrix.git#40fb822
-    https://github.com/marcmerlin/Framebuffer_GFX.git#375f06e
+    https://github.com/me-no-dev/ESPAsyncWebServer.git#40a2fd71bf899825eb0a92ddf333068e7ebb4070
+    https://github.com/coderus/ESPReactWifiManager.git#f8cb27d2f888186cc59816ee0793697e9babbc62
+    https://github.com/marcmerlin/FastLED_NeoMatrix.git#40fb822377497a7be8e1103be344104870ff0878
+    https://github.com/marcmerlin/Framebuffer_GFX.git#375f06e3a8f919767235ed4af919e44fadb9b0c2
     arduino-libraries/NTPClient@3.2.1
     arduinoFFT@1.6.2
 

--- a/src/effects/basic/ScrollingTextEffect.cpp
+++ b/src/effects/basic/ScrollingTextEffect.cpp
@@ -10,8 +10,8 @@ uint32_t textColor = CRGB(40, 40, 40);
 uint32_t bgColor = CRGB(0, 0, 0);
 bool addSpace = true;
 
-int8_t posx = 0;
-uint8_t indexx = 0;
+int16_t posx = 0;
+uint16_t indexx = 0;
 
 void readColor(const JsonObject &json, const String &key, uint32_t &myColor)
 {
@@ -45,6 +45,17 @@ ScrollingTextEffect::ScrollingTextEffect(const String &id)
 
 void ScrollingTextEffect::tick()
 {
+    const String currentLine = line;
+    const uint16_t lineLength = currentLine.length();
+    if (lineLength == 0) {
+        return;
+    }
+
+    if (indexx >= lineLength) {
+        indexx = 0;
+        posx = 0;
+    }
+
     myMatrix->fill(bgColor);
     delay(1);
 
@@ -52,19 +63,22 @@ void ScrollingTextEffect::tick()
     int16_t y1 = 0;
     uint16_t w = 0;
     uint16_t h = 0;
-    myMatrix->getCharBounds(line.charAt(indexx), &x1, &y1, &w, &h);
+    myMatrix->getCharBounds(currentLine.charAt(indexx), &x1, &y1, &w, &h);
+    if (w == 0) {
+        w = 1;
+    }
     auto posy = (mySettings->matrixSettings.height - h) / 2;
 
-    if (--posx == -w) {
+    if (--posx <= -static_cast<int16_t>(w)) {
         posx = 0;
-        if (++indexx == line.length()) {
+        if (++indexx >= lineLength) {
             indexx = 0;
         }
     }
 
-    String output = line.substring(indexx);
+    String output = currentLine.substring(indexx);
     if (indexx > 0) {
-        output += line.substring(0, indexx);
+        output += currentLine.substring(0, indexx);
     }
 
     myMatrix->setPassThruColor(textColor);
@@ -104,19 +118,23 @@ void ScrollingTextEffect::deactivate()
 void ScrollingTextEffect::initialize(const JsonObject &json)
 {
     Effect::initialize(json);
+    String nextText = text;
     if (json.containsKey(F("text"))) {
-        text = json[F("text")].as<String>();
+        nextText = json[F("text")].as<String>();
     }
     readColor(json, F("textColor"), textColor);
     readColor(json, F("bgColor"), bgColor);
+    text = nextText;
     if (addSpace) {
-        line = text + " ";
+        line = nextText + " ";
     } else {
-        line = text;
+        line = nextText;
+    }
+    if (line.length() == 0) {
+        line = " ";
     }
     posx = 0;
     indexx = 0;
-    delay(50);
 }
 
 void ScrollingTextEffect::writeSettings(JsonObject &json)


### PR DESCRIPTION
## Summary
- Render scrolling text frames from a stable copy of the current line.
- Reset and clamp the scroll cursor when text changes or the index gets out of range.
- Expand pinned Git dependency refs to full commit SHAs so current PlatformIO/Git can fetch them.

Fixes #58

## Testing
- pio run -e nodemcu
- pio run -e esp3